### PR TITLE
Remove paramiko shell invoke

### DIFF
--- a/ltp/tests/test_ssh.py
+++ b/ltp/tests/test_ssh.py
@@ -104,12 +104,12 @@ class _TestSSHSUT(_TestSUT):
         sut = SSHSUT()
         sut.setup(**kwargs)
         sut.communicate()
-        ret = sut.run_command("echo -n $UID", timeout=1)
+        ret = sut.run_command("whoami", timeout=1)
 
         if enable == "1":
-            assert ret["stdout"] == "0"
+            assert ret["stdout"] == "root\n"
         else:
-            assert ret["stdout"] != "0"
+            assert ret["stdout"] != "root\n"
 
     def test_kernel_panic(self, sut):
         """


### PR DESCRIPTION
With this patch we remove the shell invoke and we handle everything via exec_command method. The reason is that paramiko shell invoke is hard to handle and sometimes it doesn't react properly via tty. Now commands are sent to /bin/sh stdin.